### PR TITLE
This fixes a user permission bug with django-pam (at least in Django 1.4).

### DIFF
--- a/dpam/backends.py
+++ b/dpam/backends.py
@@ -2,8 +2,9 @@ import pam
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.auth.backends import ModelBackend
 
-class PAMBackend:
+class PAMBackend(ModelBackend):
     def authenticate(self, username=None, password=None):
         if pam.authenticate(username, password):
             try:


### PR DESCRIPTION
- http://stackoverflow.com/questions/2081061/django-user-get-all-permissions-is-empty-while-user-permissions-is-set
  - Quick fix:
    - Inherit from: from django.contrib.auth.backends import ModelBackend
